### PR TITLE
Fixed compile error related to non-existing directory

### DIFF
--- a/02-nuAnalysis/02-CppAnal/compile-tst.bash
+++ b/02-nuAnalysis/02-CppAnal/compile-tst.bash
@@ -1,3 +1,14 @@
 #!/bin/bash
 
+stm=$PWD
+add="/12-Bin"
+dir="$stm$add"
+
+if [[ ! -d $dir ]]
+then
+  echo "$dir does exists on your filesystem."
+  echo "Making directory..."
+  mkdir $dir
+fi
+
 g++ 01-Code/RunControl.cpp 02-Tests/RunControlTst.cpp -I01-Code `root-config --cflags --libs` -o 12-Bin/RunControlTst.exe

--- a/02-nuAnalysis/02-CppAnal/compile.bash
+++ b/02-nuAnalysis/02-CppAnal/compile.bash
@@ -1,3 +1,14 @@
 #!/bin/bash
 
+stm=$PWD
+add="/12-Bin"
+dir="$stm$add"
+
+if [[ ! -d $dir ]]
+then
+  echo "$dir does exists on your filesystem."
+  echo "Making directory..."
+  mkdir $dir
+fi
+
 g++ 01-Code/RunControl.cpp 01-Code/nuAnalysis.cpp 03-Skeleton/nuAnalysis-skeleton.cpp -I01-Code `root-config --cflags --libs` -o 12-Bin/nuAnalysis-skeleton.exe


### PR DESCRIPTION
Added checking for directory before running compile command in bash scripts. If the directory doesn't exist yet, it is created before moving on to execute the compilation.